### PR TITLE
Save theme to local storage

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -29,13 +29,25 @@ const client = new ApolloClient({
   cache: new InMemoryCache(),
 });
 
+import { useState, useEffect } from 'react';
+import { ThemeContext } from './utils/GlobalState';
+
 function App() {
+  const [theme, setTheme] = useState(localStorage.getItem('colorTheme'));
+
+  useEffect(() => {
+    document.querySelector('html').setAttribute('data-theme', theme);
+  }, [theme]);
+
   return (
     <ApolloProvider client={client}>
-      <StoreProvider>
-        <Nav />
-        <Outlet />
-      </StoreProvider>
+      <ThemeContext.Provider value={[theme, setTheme]}>
+        {console.log("top level:", theme)}
+        <StoreProvider>
+          <Nav />
+          <Outlet />
+        </StoreProvider>
+      </ThemeContext.Provider>
     </ApolloProvider>
   );
 }

--- a/client/src/components/ThemeList/index.jsx
+++ b/client/src/components/ThemeList/index.jsx
@@ -1,4 +1,9 @@
+import { useThemeContext } from '../../utils/GlobalState';
+import { useEffect } from 'react';
+
 function ThemeList() {
+  const [theme, setTheme] = useThemeContext();
+  console.log("theme component:", theme);
   // DaisyUI built-in themes from https://daisyui.com/docs/themes/
   const themes = [
     "cupcake",
@@ -35,6 +40,16 @@ function ThemeList() {
     "sunset",
   ];
 
+  const handleThemeChange = (themeName, event) => {
+    event.preventDefault();
+    setTheme(themeName);
+    document.querySelector('html').setAttribute('data-theme', theme);
+  };
+
+  useEffect(() => {
+    localStorage.setItem('colorTheme', theme);
+  }, [theme]);
+
   return (
     <details>
       <summary>
@@ -67,6 +82,7 @@ function ThemeList() {
                 className="theme-controller btn btn-sm btn-block btn-ghost justify-start"
                 aria-label={themename}
                 value={themename}
+                onChange={(event) => handleThemeChange(themename, event)}
               />
             </li>
           );

--- a/client/src/utils/GlobalState.jsx
+++ b/client/src/utils/GlobalState.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useReducer } from "react";
+import { createContext, useContext, useReducer, useState } from "react";
 import { reducer } from './reducers'
 
 const StoreContext = createContext();
@@ -20,4 +20,11 @@ const useStoreContext = () => {
   return useContext(StoreContext);
 };
 
-export { StoreProvider, useStoreContext };
+// Create context for theme that can be stored in local storage
+const ThemeContext = createContext(localStorage.getItem('colorTheme'));
+
+const useThemeContext = () => {
+  return useContext(ThemeContext);
+}
+
+export { StoreProvider, useStoreContext, ThemeContext, useThemeContext };


### PR DESCRIPTION
Originally, daisyUI sets the theme on a single page entirely using CSS.  This is great for single page apps, but the theme is reset every time the window/DOM is refreshed, such as when users log in / log out.

To make it permanent, we use React's useContext and useState to set the theme from localstorage when the user selects it.
Save the theme to localstorage upon render with useEffect.
