### PR TITLE
Fix delete not refreshing: Refetch all quotes after Delete

### DIFF
--- a/client/src/components/PostQuote/index.jsx
+++ b/client/src/components/PostQuote/index.jsx
@@ -33,25 +33,29 @@ const PostQuote = (props) => {
   // Handles posting a new Quote
   const handlePostQuote = (event) => {
     event.preventDefault();
-    createQuote({
-      variables: {
-        content: quoteText,
-        emotion: emotionText,
-        isPrivate: isJournal,
-        isGenerated: false,
-        imageUrl: imageUrlText,
-      },
-    })
-      .then((res) => {
-        console.log("Quote created:", res.data.createQuote);
-        window.location.reload();
-        setQuoteText(""); // Clear the input field after posting
-        // Adds the new quote to the list of quotes without reloading the page
-        setPosts((prevPosts) => [...prevPosts, res.data.createQuote]);
+    if (quoteText.length > 0 ) {
+      createQuote({
+        variables: {
+          content: quoteText,
+          emotion: emotionText,
+          isPrivate: isJournal,
+          isGenerated: false,
+          imageUrl: imageUrlText,
+        },
       })
-      .catch((error) => {
-        console.error("Error creating quote:", error);
-      });
+        .then((res) => {
+          console.log("Quote created:", res.data.createQuote);
+          window.location.reload();
+          setQuoteText(""); // Clear the input field after posting
+          // Adds the new quote to the list of quotes without reloading the page
+          setPosts((prevPosts) => [...prevPosts, res.data.createQuote]);
+        })
+        .catch((error) => {
+          console.error("Error creating quote:", error);
+        });
+    } else {
+      console.log("Quote is empty, cancelling post");
+    };
   };
 
   // Handles posting a new comment on a quote
@@ -105,7 +109,7 @@ const PostQuote = (props) => {
             type="text"
             name="postquote"
             value={quoteText}
-            onChange={()=>handleInputChange("postquote",event)}
+            onChange={() => handleInputChange("postquote", event)}
             placeholder="Enter your quote"
           />
           {/* emotion detector (TBD): {quoteText?(<button type="button" className="badge badge-secondary">detect emotion</button>):<div className="badge badge-outline">type in your post to detect its emotion</div>} */}
@@ -115,7 +119,7 @@ const PostQuote = (props) => {
             placeholder="How are you feeling today?"
             value={emotionText}
             name="postemotion"
-            onChange={()=>handleInputChange("postemotion",event)}
+            onChange={() => handleInputChange("postemotion", event)}
             list="emotionlist"
           />
           <datalist id="emotionlist">
@@ -129,7 +133,7 @@ const PostQuote = (props) => {
             placeholder="Enter an image URL to set a picture"
             value={imageUrlText}
             name="imageurl"
-            onChange={()=>handleInputChange("imageurl",event)}
+            onChange={() => handleInputChange("imageurl", event)}
           />
           <button type="submit" className="btn btn-primary">
             {loading ? "Posting Quote..." : "Post Quote"}

--- a/client/src/components/ShowQuotes/index.jsx
+++ b/client/src/components/ShowQuotes/index.jsx
@@ -9,7 +9,9 @@ const ShowQuotes = (props) => {
   const userName = Auth.getProfile().data.userName;
   const [setPublic, setPublicState] = useMutation(SET_PUBLIC);
   const [setPrivate, setPrivateState] = useMutation(SET_PRIVATE);
-  const [deleteQuote, deleteQuoteState] = useMutation(DELETE_QUOTE);
+  const [deleteQuote, deleteQuoteState] = useMutation(DELETE_QUOTE, {
+    refetchQueries: [{ query: props.quotesQuery }],
+  });
   const [addReaction, addReactionState] = useMutation(ADD_REACTION);
   const [delReaction, delReactionState] = useMutation(DEL_REACTION);
 
@@ -32,7 +34,10 @@ const ShowQuotes = (props) => {
       analyzeQuote().then((response) => {
         let newAiQuotes = {};
         let newAiQuote = { _id: null };
-        newAiQuote[response.data.analyzeQuote._id] = { content: response.data.analyzeQuote.content, emotion: response.data.analyzeQuote.emotion };
+        newAiQuote[response.data.analyzeQuote._id] = {
+          content: response.data.analyzeQuote.content,
+          emotion: response.data.analyzeQuote.emotion,
+        };
         Object.assign(newAiQuotes, aiQuotes, newAiQuote);
         setAiQuotes(newAiQuotes);
       });

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -9,6 +9,7 @@ import Auth from "../utils/auth";
 import PostQuote from "../components/PostQuote";
 import ShowQuotes from "../components/ShowQuotes";
 
+import { useState } from "react";
 // Apollo GraphQL queries
 import { useQuery } from "@apollo/client";
 import { useMutation } from "@apollo/client";
@@ -42,14 +43,16 @@ const DashBoard = () => {
   return (
     <>
       <div className="container border rounded-box">
-        <div className="rounded-box">
+        <div className="rounded-box p-2">
           <h2>Public Dashboard</h2>
           <p className="text-sm">
-            Shared quote posts from all users, including your own posts. You can like or delete likes on all posts. But you can only modify/delete your own posts. Any quotes you post here will be shared, but you can set them to private later.
+            Shared quote posts from all users, including your own posts. You can like or delete likes on all posts. But
+            you can only modify/delete your own posts. Any quotes you post here will be shared, but you can set them to
+            private later.
           </p>
         </div>
         <PostQuote />
-        <ShowQuotes quotesArray={data.publicQuotes} />
+        <ShowQuotes quotesArray={data.publicQuotes} quotesQuery={QUERY_GET_PUBLIC_QUOTES} />
       </div>
     </>
   );

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -9,10 +9,8 @@ import Auth from "../utils/auth";
 import PostQuote from "../components/PostQuote";
 import ShowQuotes from "../components/ShowQuotes";
 
-import { useState } from "react";
 // Apollo GraphQL queries
 import { useQuery } from "@apollo/client";
-import { useMutation } from "@apollo/client";
 import { QUERY_GET_PUBLIC_QUOTES } from "../utils/queries";
 
 const DashBoard = () => {

--- a/client/src/pages/Journal.jsx
+++ b/client/src/pages/Journal.jsx
@@ -11,7 +11,6 @@ import ShowQuotes from "../components/ShowQuotes";
 
 // Apollo GraphQL queries
 import { useQuery } from "@apollo/client";
-import { useMutation } from "@apollo/client";
 import { QUERY_GET_MY_QUOTES } from "../utils/queries";
 
 const Journal = () => {

--- a/client/src/pages/Journal.jsx
+++ b/client/src/pages/Journal.jsx
@@ -19,7 +19,7 @@ const Journal = () => {
 
   const userId = Auth.getProfile().data._id;
 
-  const { loading, data } = useQuery(QUERY_GET_MY_QUOTES, {});
+  const { loading, data } = useQuery(QUERY_GET_MY_QUOTES);
 
   // populate quoteData
   if (data) {
@@ -43,12 +43,12 @@ const Journal = () => {
 
   return (
     <div className="container border rounded-box">
-      <div className="rounded-box">
+      <div className="rounded-box p-2">
         <h2>Private Journal</h2>
         <p className="text-sm">Your private journal lists all of your private posts to keep track of your emotional journey. You can share your posts to the public. You can also get an AI to generate an affirmation to your post. Any post you make here will be private, but you can share it to the public later.</p>
       </div>
       <PostQuote isJournal={true} />
-      <ShowQuotes quotesArray={quoteData} />
+      <ShowQuotes quotesArray={quoteData} quotesQuery={QUERY_GET_MY_QUOTES}/>
     </div>
   );
 };

--- a/server/seed/quoteseed.js
+++ b/server/seed/quoteseed.js
@@ -14,7 +14,7 @@ connection.on('error', (err) => err);
 connection.once('open', async () => {
   console.log('connected');
   // Use cleandb on prevoius .js file to delete the collections if they exist
-  
+
   // Create empty array to hold users
   const users = [];
   // Loop 20 times -- add users to the users array
@@ -75,7 +75,7 @@ connection.once('open', async () => {
     "https://cdn.pixabay.com/photo/2016/11/29/11/45/children-1869265_1280.jpg",
     "https://cdn.pixabay.com/photo/2016/03/05/13/05/family-1237701_1280.jpg",
     "https://cdn.pixabay.com/photo/2016/11/18/14/40/balcony-1834990_1280.jpg",
-    "https://cdn.pixabay.com/photo/2015/06/22/08/37/children-817365_1280.jpg",                                
+    "https://cdn.pixabay.com/photo/2015/06/22/08/37/children-817365_1280.jpg",
   ]
 
   const sadImages = [
@@ -88,7 +88,7 @@ connection.once('open', async () => {
     "https://cdn.pixabay.com/photo/2017/02/08/13/43/woman-2048905_1280.jpg",
     "https://cdn.pixabay.com/photo/2020/04/07/04/17/desperate-5011953_1280.jpg",
     "https://cdn.pixabay.com/photo/2014/11/13/06/12/boy-529067_1280.jpg",
-    "https://cdn.pixabay.com/photo/2016/03/27/19/20/indian-1283789_1280.jpg",                                
+    "https://cdn.pixabay.com/photo/2016/03/27/19/20/indian-1283789_1280.jpg",
   ]
 
   const anxiousImages = [
@@ -101,7 +101,7 @@ connection.once('open', async () => {
     "https://cdn.pixabay.com/photo/2016/05/04/07/49/face-1370956_1280.jpg",
     "https://cdn.pixabay.com/photo/2020/01/01/21/52/cat-4734564_1280.jpg",
     "https://cdn.pixabay.com/photo/2021/06/18/14/03/woman-6346248_1280.jpg",
-    "https://cdn.pixabay.com/photo/2018/12/12/04/43/sad-3870115_1280.jpg",                                
+    "https://cdn.pixabay.com/photo/2018/12/12/04/43/sad-3870115_1280.jpg",
   ]
 
   const angryImages = [
@@ -114,7 +114,7 @@ connection.once('open', async () => {
     "https://cdn.pixabay.com/photo/2015/09/03/17/28/man-921004_1280.jpg",
     "https://cdn.pixabay.com/photo/2012/02/29/11/51/anger-18615_1280.jpg",
     "https://cdn.pixabay.com/photo/2013/07/12/16/39/angry-151332_1280.png",
-    "https://cdn.pixabay.com/photo/2017/05/04/14/19/warning-2284170_1280.jpg",                                
+    "https://cdn.pixabay.com/photo/2017/05/04/14/19/warning-2284170_1280.jpg",
   ]
 
   const stressedImages = [
@@ -127,47 +127,51 @@ connection.once('open', async () => {
     "https://cdn.pixabay.com/photo/2016/10/13/15/39/hustle-and-bustle-1738072_1280.jpg",
     "https://cdn.pixabay.com/photo/2017/05/15/00/37/mental-health-2313430_1280.jpg",
     "https://cdn.pixabay.com/photo/2017/05/31/16/24/cat-2360863_1280.jpg",
-    "https://cdn.pixabay.com/photo/2018/03/30/13/10/woman-3275328_1280.jpg",                                
+    "https://cdn.pixabay.com/photo/2018/03/30/13/10/woman-3275328_1280.jpg",
   ]
 
   const moods = [
-    'happy', 
-    'sad', 
-    'anxious', 
-    'angry', 
-    'stressed', 
-    'lonely', 
-    'overwhelmed', 
-    'frustrated', 
-    'disappointed', 
-    'grateful', 
-    'exhausted',     
-    'inseucure',         
+    'happy',
+    'sad',
+    'anxious',
+    'angry',
+    'stressed',
+    'lonely',
+    'overwhelmed',
+    'frustrated',
+    'disappointed',
+    'grateful',
+    'exhausted',
+    'inseucure',
     'nervous',
-    'hopeless',                 
-    'jealous',                 
-    'lost',    
+    'hopeless',
+    'jealous',
+    'lost',
   ];
 
   const Chartmoods = [
-    'happy', 
-    'sad', 
-    'anxious', 
-    'angry', 
-    'stressed', 
+    'happy',
+    'sad',
+    'anxious',
+    'angry',
+    'stressed',
   ];
 
 
   // Seed quotes & reactions
   // =========================
+
+  // Make most posts from last week to show something in the chart
+  const currentDate = new Date();
+  const lastWeekDate = new Date(currentDate.getTime() - 7 * 24 * 60 * 60 * 1000);
+
   // Get some random quote objects using a helper function that we imported from ./data
   let quotes = [];
-  for (let i = 1; i <= 35; i++) {
-    const emotion = Chartmoods[Math.floor(Math.random()*Chartmoods.length)];
+  for (let i = 1; i <= 185; i++) {
+    const emotion = Chartmoods[Math.floor(Math.random() * Chartmoods.length)];
     let image, selectedImage;
-  
-    switch (emotion)
-    {
+
+    switch (emotion) {
       case 'happy':
         image = happyImages.sort(() => 0.5 - Math.random());
         break;
@@ -182,9 +186,9 @@ connection.once('open', async () => {
         break;
       case 'stressed':
         image = stressedImages.sort(() => 0.5 - Math.random());
-        break;        
+        break;
     }
-  
+
     selectedImage = image[0];
 
 
@@ -192,55 +196,52 @@ connection.once('open', async () => {
       content: getRandomQuote(),
       userName: getRandomArrItem(users).userName,
       emotion: emotion,
-      isPrivate: (Math.random() < 0.5)?true:false,
+      isPrivate: (Math.random() < 0.5) ? true : false,
       isGenerated: false,
       // isGenerated: (Math.random() < 0.5)?true:false,
-//      imageUrl: `http://placekitten.com/${100+(Math.floor(Math.random()*10)*10)}/${100+(Math.floor(Math.random()*10)*10)}`,
+      //      imageUrl: `http://placekitten.com/${100+(Math.floor(Math.random()*10)*10)}/${100+(Math.floor(Math.random()*10)*10)}`,
       imageUrl: selectedImage,
-      createdAt: generateRandomDate(new Date(2021, 0, 1), new Date())
+      createdAt: generateRandomDate(lastWeekDate, currentDate)
     });
   };
 
-// add more quotes for EmotionChart
-const currentDate = new Date();
-const lastWeekDate = new Date(currentDate.getTime() - 7*24*60*60*1000);
+  // add additional quotes for on user[1] only for EmotionChart
 
-for (let i = 1; i <= 50; i++) {
-  const emotion = Chartmoods[Math.floor(Math.random()*Chartmoods.length)];
-  let image, selectedImage;
+  for (let i = 1; i <= 18; i++) {
+    const emotion = Chartmoods[Math.floor(Math.random() * Chartmoods.length)];
+    let image, selectedImage;
 
-  switch (emotion)
-  {
-    case 'happy':
-      image = happyImages.sort(() => 0.5 - Math.random());
-      break;
-    case 'sad':
-      image = sadImages.sort(() => 0.5 - Math.random());
-      break;
-    case 'anxious':
-      image = anxiousImages.sort(() => 0.5 - Math.random());
-      break;
-    case 'angry':
-      image = angryImages.sort(() => 0.5 - Math.random());
-      break;
-    case 'stressed':
-      image = stressedImages.sort(() => 0.5 - Math.random());
-      break;        
-  }
+    switch (emotion) {
+      case 'happy':
+        image = happyImages.sort(() => 0.5 - Math.random());
+        break;
+      case 'sad':
+        image = sadImages.sort(() => 0.5 - Math.random());
+        break;
+      case 'anxious':
+        image = anxiousImages.sort(() => 0.5 - Math.random());
+        break;
+      case 'angry':
+        image = angryImages.sort(() => 0.5 - Math.random());
+        break;
+      case 'stressed':
+        image = stressedImages.sort(() => 0.5 - Math.random());
+        break;
+    }
 
-  selectedImage = image[0];
+    selectedImage = image[0];
 
-  quotes.push({
-    content: getRandomQuote(),
-    userName: users[1].userName,      // push to user[1]
-    emotion: emotion,
-    isPrivate: (Math.random() < 0.5)?true:false,
-    isGenerated: false,
-    // isGenerated: (Math.random() < 0.5)?true:false,
-    imageUrl: selectedImage,
-    createdAt: generateRandomDate(lastWeekDate, currentDate)
-  });
-};
+    quotes.push({
+      content: getRandomQuote(),
+      userName: users[1].userName,      // push to user[1]
+      emotion: emotion,
+      isPrivate: (Math.random() < 0.5) ? true : false,
+      isGenerated: false,
+      // isGenerated: (Math.random() < 0.5)?true:false,
+      imageUrl: selectedImage,
+      createdAt: generateRandomDate(lastWeekDate, currentDate)
+    });
+  };
 
 
 


### PR DESCRIPTION
This change fixes the issue where react continues to display an already-deleted quote.

Deleteing quotes succeeds to the backend, but react doesn't re-render the entire list, so the deleted post remains shown.
(This was why we previously did a window.refresh() which was slow and disruptive to the UI)

Apollo Queries/Mutations should cause its react component to re-render after changes.  So when we call the delete mutation, we can pass it an option to force Apollo to refetch the entire array.

See: https://www.apollographql.com/blog/when-to-use-refetch-queries

